### PR TITLE
Adding a "use_ssl" switch

### DIFF
--- a/lib/zapix/version.rb
+++ b/lib/zapix/version.rb
@@ -1,3 +1,3 @@
 module Zapix
-  VERSION = '0.2.5'.freeze
+  VERSION = '0.2.6'.freeze
 end

--- a/lib/zapix/zabbix_rpc_client.rb
+++ b/lib/zapix/zabbix_rpc_client.rb
@@ -9,6 +9,7 @@ class ZabbixRPCClient
     @uri = URI.parse(options[:service_url])
     @username = options[:username]
     @password = options[:password]
+    @use_ssl = options.fetch(:use_ssl, true)
     @debug = options[:debug]
     @auth_token = authenticate
   end
@@ -32,7 +33,7 @@ class ZabbixRPCClient
 
   def http_post_request(post_body)
     http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = true
+    http.use_ssl = @use_ssl
     request = Net::HTTP::Post.new(uri.request_uri)
     request.content_type = 'application/json'
     request.body = post_body


### PR DESCRIPTION
There is the use case, where some want to use the api on the same
host, where the application runs, while using localhost as hostname.
It is okay there to not speak ssl in some cases, which makes the thing
with "localhost" much easier, so I added a use_ssl-switch which is true
on default. You can pass it in when initializing the ZabbixAPI-Object.